### PR TITLE
Add sql plugin to info.json

### DIFF
--- a/info.json
+++ b/info.json
@@ -65,6 +65,17 @@
         "dockerfile"
       ],
       "configExcludes": []
+    },
+    {
+      "name": "dprint-plugin-sql",
+      "version": "0.1.1",
+      "selected": false,
+      "url": "https://plugins.dprint.dev/sql-0.1.1.wasm",
+      "configKey": "sql",
+      "fileExtensions": [
+        "sql"
+      ],
+      "configExcludes": []
     }
   ]
 }


### PR DESCRIPTION
I noticed that I can download the `sql` plugin through `plugins.dprint.dev`, but that it's not displayed on the homepage.

_If this was intentional, then please close and sorry for the bother._