### PR TITLE
Add hrko/dprint-plugin-shfmt

### DIFF
--- a/info.json
+++ b/info.json
@@ -181,6 +181,20 @@
         "gql"
       ],
       "configExcludes": []
+    },
+    {
+      "name": "hrko/dprint-plugin-shfmt",
+      "description": "shfmt (Shell) wrapper plugin.",
+      "selected": false,
+      "configKey": "shfmt",
+      "fileExtensions": [
+        "sh",
+        "bash",
+        "zsh",
+        "mksh",
+        "bats"
+      ],
+      "configExcludes": []
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add `hrko/dprint-plugin-shfmt` to `info.json`

## Notes

- plugin repository: https://github.com/hrko/dprint-plugin-shfmt
