### PR TITLE
fix: prefer asset digest for checksums

### DIFF
--- a/utils/github.ts
+++ b/utils/github.ts
@@ -58,19 +58,20 @@ function getReleaseInfo(data: GitHubRelease): ReleaseInfo {
   };
 
   function getChecksum() {
-    if (typeof data.body === "string") {
-      // search the body text for a dprint style checksum
-      const checksum = /\@([a-z0-9]{64})\b/i.exec(data.body);
-      if (checksum?.[1]) {
-        return checksum[1];
-      }
-    }
-    // fall back to the digest from the release asset
     const assetName = getPluginKind() === "wasm" ? "plugin.wasm" : "plugin.json";
     const asset = data.assets?.find((a) => a.name === assetName);
     if (asset?.digest) {
       const match = /^sha256:([a-f0-9]{64})$/i.exec(asset.digest);
-      return match?.[1];
+      if (match?.[1]) {
+        return match[1];
+      }
+    }
+    // fall back to searching the body text for a dprint style checksum
+    if (typeof data.body === "string") {
+      const checksum = /\@([a-z0-9]{64})\b/i.exec(data.body);
+      if (checksum?.[1]) {
+        return checksum[1];
+      }
     }
     return undefined;
   }


### PR DESCRIPTION
More reliable when there's multiple checksums.