### PR TITLE
Add lax-css, lax-markup, and lax-sql plugins

### DIFF
--- a/info.json
+++ b/info.json
@@ -181,6 +181,46 @@
         "gql"
       ],
       "configExcludes": []
+    },
+    {
+      "name": "bartlomieju/lax-css",
+      "description": "CSS, SCSS, and Less formatter that never reinterprets your styles.",
+      "selected": false,
+      "configKey": "css",
+      "fileExtensions": [
+        "css",
+        "scss",
+        "less"
+      ],
+      "configExcludes": [
+        "**/node_modules"
+      ]
+    },
+    {
+      "name": "bartlomieju/lax-markup",
+      "description": "HTML, XML, SVG, Vue, Svelte, and Astro formatter that preserves rendering-critical whitespace.",
+      "selected": false,
+      "configKey": "markup",
+      "fileExtensions": [
+        "html",
+        "htm",
+        "vue",
+        "svelte",
+        "astro",
+        "xml",
+        "svg"
+      ],
+      "configExcludes": []
+    },
+    {
+      "name": "bartlomieju/lax-sql",
+      "description": "Dialect-agnostic SQL formatter.",
+      "selected": false,
+      "configKey": "sql",
+      "fileExtensions": [
+        "sql"
+      ],
+      "configExcludes": []
     }
   ]
 }


### PR DESCRIPTION
Adds three Wasm formatter plugins from the lax family to the registry:

- `bartlomieju/lax-css` (configKey `css`) — CSS, SCSS, and Less.
- `bartlomieju/lax-markup` (configKey `markup`) — HTML, XML, SVG, Vue,
  Svelte, and Astro.
- `bartlomieju/lax-sql` (configKey `sql`) — dialect-agnostic SQL.

Each is published as a single `plugin.wasm` asset on its own GitHub repo and
already resolves through the redirect service, e.g.
https://plugins.dprint.dev/bartlomieju/lax-css/latest.json. They build against
`dprint-core` 0.67.4.

All three are marked `"selected": false`. lax-css and lax-markup are
alternative implementations overlapping the existing malva and markup_fmt
plugins, so they are intentionally left out of the default `dprint init`
selection to avoid clashing with those.