### PR TITLE
Add Panache plugin

### DIFF
--- a/info.json
+++ b/info.json
@@ -181,6 +181,24 @@
         "gql"
       ],
       "configExcludes": []
+    },
+    {
+      "name": "jolars/panache",
+      "description": "Quarto, Pandoc, R Markdown, and Markdown formatter.",
+      "selected": false,
+      "configKey": "panache",
+      "fileExtensions": [
+        "md",
+        "qmd",
+        "Rmd",
+        "rmd",
+        "Rmarkdown",
+        "rmarkdown",
+        "markdown",
+        "mdown",
+        "mkd"
+      ],
+      "configExcludes": []
     }
   ]
 }


### PR DESCRIPTION
Adds Panache (<https://panache.bz>), which is a formatter for Markdown, Quarto, and R Markdown. The repo for the dprint plugin is at <https://github.com/jolars/dprint-plugin-panache>.