### PR TITLE
CDN caching for drluckyspin/dprint-plugin-swift

### DIFF
--- a/plugins.test.ts
+++ b/plugins.test.ts
@@ -37,6 +37,17 @@ it("tryResolveAssetUrl", () => {
     shouldCache: true,
   });
 
+  // approved community repo — should cache
+  expect(
+    resolveAsset(
+      "https://plugins.dprint.dev/drluckyspin/dprint-plugin-swift/v0.1.0/asset/dprint-plugin-swift-aarch64-apple-darwin.zip",
+    ),
+  ).toEqual({
+    githubUrl:
+      "https://github.com/drluckyspin/dprint-plugin-swift/releases/download/v0.1.0/dprint-plugin-swift-aarch64-apple-darwin.zip",
+    shouldCache: true,
+  });
+
   // org not on allow list — resolves but should not cache (redirect)
   expect(
     resolveAsset("https://plugins.dprint.dev/someone/some-repo/0.1.0/asset/file.zip"),

--- a/plugins.ts
+++ b/plugins.ts
@@ -45,6 +45,7 @@ const KNOWN_DPRINT_PLUGIN_REPOS = new Set([
   // community
   "jakebailey/dprint-plugin-gofumpt",
   "malobre/dprint-plugin-vue",
+  "drluckyspin/dprint-plugin-swift",
 ]);
 
 // repos where the short name IS the repo name (no dprint-plugin- prefix)
@@ -56,13 +57,15 @@ const KNOWN_NON_PREFIXED_REPOS = new Set([
   "lucacasonato/mf2-tools",
 ]);
 
-export function isAssetAllowedRepo(username: string, _repo: string) {
-  switch (username) {
-    case "dprint":
-      return true;
-    default:
-      return false;
+const APPROVED_ASSET_REPOS = new Set([
+  "drluckyspin/dprint-plugin-swift",
+]);
+
+export function isAssetAllowedRepo(username: string, repo: string) {
+  if (username === "dprint") {
+    return true;
   }
+  return APPROVED_ASSET_REPOS.has(`${username}/${repo}`);
 }
 
 const assetNamePattern = "([A-Za-z0-9\\-\\._]+)";


### PR DESCRIPTION
## Summary

- Approve `drluckyspin/dprint-plugin-swift` for release asset CDN caching on `plugins.dprint.dev`
- Add the repo to `KNOWN_DPRINT_PLUGIN_REPOS` so the `swift` short name resolves without a GitHub API lookup

## Plugin

[dprint-plugin-swift](https://github.com/drluckyspin/dprint-plugin-swift) is a process plugin (schema v5) that formats Swift via bundled SwiftFormat binaries for macOS and Linux (x86_64 + aarch64).

Release assets per tag:

- `plugin.json`
- `schema.json`
- `latest.json`
- `dprint-plugin-swift-<target>.zip` (4 platforms)

Example CDN URLs:

- `https://plugins.dprint.dev/drluckyspin/dprint-plugin-swift/v0.1.0/asset/plugin.json`
- `https://plugins.dprint.dev/drluckyspin/dprint-plugin-swift/v0.1.0/schema.json`
- `https://plugins.dprint.dev/drluckyspin/dprint-plugin-swift/latest.json`

## Test plan

- [x] Unit test added for `tryResolveAssetUrl` with `shouldCache: true`
- [ ] CI passes on this PR