### PR TITLE
Add drluckyspin/dprint-plugin-swift plugin

### DIFF
--- a/info.json
+++ b/info.json
@@ -241,7 +241,7 @@
       "configExcludes": []
     },
     {
-      "name": "drluckyspin/dprint-plugin-swift",
+      "name": "drluckyspin/swift",
       "description": "Swift code formatter (SwiftFormat wrapper).",
       "selected": false,
       "configKey": "swiftformat",

--- a/info.json
+++ b/info.json
@@ -181,6 +181,16 @@
         "gql"
       ],
       "configExcludes": []
+    },
+    {
+      "name": "drluckyspin/dprint-plugin-swift",
+      "description": "Swift code formatter (SwiftFormat wrapper).",
+      "selected": false,
+      "configKey": "swiftformat",
+      "fileExtensions": [
+        "swift"
+      ],
+      "configExcludes": []
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add [dprint-plugin-swift](https://github.com/drluckyspin/dprint-plugin-swift) to `info.json` for the [plugins.dprint.dev](https://plugins.dprint.dev) homepage
- Enables discovery via `dprint add` and shows the latest plugin URL on the site

## Plugin details

| Field | Value |
| ----- | ----- |
| Name | `drluckyspin/dprint-plugin-swift` |
| Config key | `swiftformat` |
| Extensions | `swift` |
| Kind | Process plugin (bundled SwiftFormat) |
| Platforms | macOS + Linux (x86_64, aarch64) |

Latest release: [v0.1.0](https://github.com/drluckyspin/dprint-plugin-swift/releases/tag/v0.1.0)

## Related

- Asset CDN approval: #57

## Test plan

- [ ] CI passes
- [ ] After deploy, plugin appears on https://plugins.dprint.dev with a resolvable latest URL