### PR TITLE
Cache info.json with background refresh

### DIFF
--- a/handleRequest.ts
+++ b/handleRequest.ts
@@ -68,7 +68,7 @@ export function createRequestHandler() {
       }
 
       if (url.pathname.startsWith("/info.json")) {
-        const infoFileData = await readInfoFile(url.origin);
+        const infoFileData = await readInfoFile(url.origin, ctx);
         return createJsonResponse(
           JSON.stringify(infoFileData, null, 2),
           request,
@@ -97,7 +97,7 @@ export function createRequestHandler() {
       }
 
       if (url.pathname === "/") {
-        return renderHome(url.origin).then((home) =>
+        return renderHome(url.origin, ctx).then((home) =>
           new Response(home, {
             headers: {
               "content-type": contentTypes.html,

--- a/home.tsx
+++ b/home.tsx
@@ -1,8 +1,8 @@
 import { renderToString } from "preact-render-to-string";
 import { PluginData, PluginsData, readInfoFile } from "./readInfoFile.js";
 
-export async function renderHome(origin: string) {
-  const content = await renderContent(origin);
+export async function renderHome(origin: string, ctx?: ExecutionContext) {
+  const content = await renderContent(origin, ctx);
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -34,8 +34,8 @@ export async function renderHome(origin: string) {
 `;
 }
 
-async function renderContent(origin: string) {
-  const pluginsData = await readInfoFile(origin);
+async function renderContent(origin: string, ctx?: ExecutionContext) {
+  const pluginsData = await readInfoFile(origin, ctx);
   const section = (
     <section id="content">
       <h1>Plugins</h1>

--- a/readInfoFile.ts
+++ b/readInfoFile.ts
@@ -1,3 +1,4 @@
+import { env } from "cloudflare:workers";
 import infoJson from "./info.json" with { type: "json" };
 import { getLatestInfo } from "./plugins.js";
 import { getAllDownloadCount } from "./utils/github.js";
@@ -17,7 +18,107 @@ export interface PluginData {
   };
 }
 
-export async function readInfoFile(origin: string): Promise<Readonly<PluginsData>> {
+interface CacheEntry {
+  data: Readonly<PluginsData>;
+  builtAt: number;
+}
+
+// Assembling the info file makes a sequential GitHub API request per plugin, so
+// it's cached in memory and persisted to R2 (shared across isolates). Entries are
+// keyed by origin because the resolved plugin urls embed the request's origin.
+const REFRESH_AFTER_MS = 5 * 60 * 1_000; // past this, serve the cached copy but refresh in the background
+const MAX_STALE_MS = 6 * 60 * 60 * 1_000; // past this, block and rebuild rather than serve stale data
+
+const memoryCache = new Map<string, CacheEntry>();
+const inFlightBuilds = new Map<string, Promise<CacheEntry>>();
+
+export async function readInfoFile(origin: string, ctx?: ExecutionContext): Promise<Readonly<PluginsData>> {
+  const now = Date.now();
+
+  const memEntry = memoryCache.get(origin);
+  if (memEntry != null && now - memEntry.builtAt < REFRESH_AFTER_MS) {
+    return memEntry.data; // fresh in memory
+  }
+
+  // memory is missing or stale — fall back to the freshest of memory and R2
+  const entry = freshest(memEntry, await getFromR2(origin));
+  if (entry != null) {
+    memoryCache.set(origin, entry);
+    const age = now - entry.builtAt;
+    if (age < REFRESH_AFTER_MS) {
+      return entry.data; // R2 had a fresh copy
+    }
+    if (age < MAX_STALE_MS) {
+      refreshInBackground(origin, ctx);
+      return entry.data; // serve stale while it refreshes
+    }
+    // older than the max — fall through and rebuild synchronously
+  }
+
+  return (await build(origin)).data;
+}
+
+function freshest(a: CacheEntry | undefined, b: CacheEntry | undefined) {
+  if (a == null) return b;
+  if (b == null) return a;
+  return a.builtAt >= b.builtAt ? a : b;
+}
+
+function refreshInBackground(origin: string, ctx?: ExecutionContext) {
+  if (inFlightBuilds.has(origin)) {
+    return; // a rebuild is already running
+  }
+  const promise = build(origin).catch((err) => {
+    console.error("Failed to refresh info.json cache.", err);
+  });
+  ctx?.waitUntil(promise);
+}
+
+// dedupes concurrent rebuilds for the same origin so the work happens once
+function build(origin: string): Promise<CacheEntry> {
+  let promise = inFlightBuilds.get(origin);
+  if (promise == null) {
+    promise = buildAndStore(origin).finally(() => inFlightBuilds.delete(origin));
+    inFlightBuilds.set(origin, promise);
+  }
+  return promise;
+}
+
+async function buildAndStore(origin: string): Promise<CacheEntry> {
+  const entry: CacheEntry = { data: await buildInfoFile(origin), builtAt: Date.now() };
+  memoryCache.set(origin, entry);
+  await putToR2(origin, entry.data);
+  return entry;
+}
+
+function r2Key(origin: string) {
+  return `info-cache/${encodeURIComponent(origin)}.json`;
+}
+
+async function getFromR2(origin: string): Promise<CacheEntry | undefined> {
+  try {
+    const object = await env.PLUGIN_CACHE.get(r2Key(origin));
+    if (object == null) {
+      return undefined;
+    }
+    return { data: await object.json(), builtAt: object.uploaded.getTime() };
+  } catch (err) {
+    console.error("Failed to read info.json cache from R2.", err);
+    return undefined;
+  }
+}
+
+async function putToR2(origin: string, data: Readonly<PluginsData>) {
+  try {
+    await env.PLUGIN_CACHE.put(r2Key(origin), JSON.stringify(data), {
+      httpMetadata: { contentType: "application/json; charset=utf-8" },
+    });
+  } catch (err) {
+    console.error("Failed to write info.json cache to R2.", err);
+  }
+}
+
+async function buildInfoFile(origin: string): Promise<Readonly<PluginsData>> {
   return {
     ...infoJson,
     latest: await getLatest(infoJson.latest),


### PR DESCRIPTION
## Summary

`info.json` (used by `dprint init` / `dprint add` and the plugins.dprint.dev home page) is assembled by making a sequential GitHub API request per plugin to resolve each plugin's latest version, URL, and download counts. On a cold cache that's ~19 serialized GitHub calls before the response, and it was being paid repeatedly.

This caches the assembled result and refreshes it in the background so requests almost never wait on GitHub.

## How it works

The assembled `info.json` is cached in memory **and** persisted to R2 (shared across isolates), keyed by origin (the resolved plugin URLs embed the request origin). Each request serves based on the cached copy's age:

- **< 5 minutes** → serve as-is, no I/O
- **5 minutes – 6 hours** → serve the cached copy immediately and refresh in the background via `ctx.waitUntil`
- **> 6 hours** → block and rebuild rather than serve stale data
- **nothing cached** → block and build (only the very first request after R2 is empty)

A freshly-warmed isolate adopts R2's copy instead of rebuilding, and an `inFlightBuilds` map dedupes concurrent rebuilds per origin so the work happens once.

## Notes

- `ctx` is threaded through `/info.json`, `renderHome`, and `renderContent` so background refreshes outlive the response.
- The in-memory maps are keyed by origin (limited to the worker's own domains), so they don't grow unbounded.