### PR TITLE
Fix CORS on redirect responses and add Vary: Origin

### DIFF
--- a/handleRequest.test.ts
+++ b/handleRequest.test.ts
@@ -335,6 +335,7 @@ it("should redirect non-wasm plugins to asset URL", async () => {
   expect(response.headers.get("location")).toEqual(
     "https://plugins.dprint.dev/dprint/dprint-plugin-prettier/0.7.0/asset/plugin.json",
   );
+  expect(response.headers.get("access-control-allow-origin")).toEqual("https://dprint.dev");
 });
 
 it("should not redirect wasm plugins", async () => {
@@ -354,6 +355,7 @@ it("should redirect non-allowed org asset to GitHub", async () => {
   expect(response.headers.get("location")).toEqual(
     "https://github.com/someone/some-repo/releases/download/0.1.0/file.zip",
   );
+  expect(response.headers.get("access-control-allow-origin")).toEqual("https://dprint.dev");
 });
 
 it("should return 404 for asset not found", async () => {

--- a/handleRequest.ts
+++ b/handleRequest.ts
@@ -35,7 +35,7 @@ export function createRequestHandler() {
       const assetResult = tryResolveAssetUrl(url);
       if (assetResult != null) {
         if (!assetResult.shouldCache) {
-          return Response.redirect(assetResult.githubUrl, 302);
+          return createRedirectResponse(request, assetResult.githubUrl);
         }
         return servePlugin(request, assetResult.githubUrl, ctx);
       }
@@ -47,7 +47,7 @@ export function createRequestHandler() {
           // plugin.json files resolve correctly
           const assetPath = githubUrlToAssetPath(githubUrl);
           if (assetPath != null) {
-            return Response.redirect(`${url.origin}${assetPath}`, 302);
+            return createRedirectResponse(request, `${url.origin}${assetPath}`);
           }
         }
         return servePlugin(request, githubUrl, ctx);
@@ -124,6 +124,7 @@ export function createRequestHandler() {
       headers: {
         "content-type": result.contentType,
         "Access-Control-Allow-Origin": getAccessControlAllowOrigin(request),
+        "Vary": "Origin",
       },
       status: result.status,
     });
@@ -209,6 +210,20 @@ export async function resolvePluginOrSchemaUrl(url: URL) {
   return await tryResolveSchemaUrl(url);
 }
 
+// builds a redirect that also carries the CORS header, because for
+// cross-origin fetches the browser runs the CORS check on the redirect
+// response itself — not just the final response it points at
+function createRedirectResponse(request: Request, location: string) {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "location": location,
+      "Access-Control-Allow-Origin": getAccessControlAllowOrigin(request),
+      "Vary": "Origin",
+    },
+  });
+}
+
 function getAccessControlAllowOrigin(request: Request) {
   const origin = request.headers.get("origin");
   return origin != null && isLocalHostname(new URL(origin).hostname)
@@ -225,6 +240,7 @@ function createJsonResponse(text: string, request: Request) {
     headers: {
       "content-type": contentTypes.json,
       "Access-Control-Allow-Origin": getAccessControlAllowOrigin(request),
+      "Vary": "Origin",
     },
     status: 200,
   });


### PR DESCRIPTION
## Problem

Cross-origin fetches from `https://dprint.dev` to schema/plugin URLs were failing with:

> Access to fetch at '.../schema.json' from origin 'https://dprint.dev' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

A request for a non-wasm asset (e.g. `schema.json`, `plugin.json`) returns a `302` redirect to the `/asset/...` path so relative URLs resolve correctly. The final asset response set `Access-Control-Allow-Origin`, but the `302` from `Response.redirect()` did not. For CORS-mode requests the browser runs the CORS check on **every** response in the redirect chain, so the naked redirect was blocked before the final response was reached.

## Fix

- Add a `createRedirectResponse(request, location)` helper that builds the `302` with the `Access-Control-Allow-Origin` header (reusing the existing `getAccessControlAllowOrigin`, which already echoes `localhost`/`127.0.0.1` origins for local dev). Both redirect sites now use it.
- Add `Vary: Origin` to every response that emits the dynamic ACAO header (plugin, JSON, and redirect responses), so caches don't serve a response cached for one origin to another.

## Tests

Extended the two existing redirect tests to assert the ACAO header is present. The only failing tests (`info.json`, `cli.json`) are pre-existing and require live GitHub credentials.

Closes https://github.com/dprint/plugins/issues/52